### PR TITLE
Update SnackBar to display properly

### DIFF
--- a/TTGSnackbar/TTGSnackbar.swift
+++ b/TTGSnackbar/TTGSnackbar.swift
@@ -80,6 +80,9 @@ open class TTGSnackbar: UIView {
     /// Second action block
     open dynamic var secondActionBlock: TTGActionBlock? = nil
 
+    /// Called before starting to dismiss the snackbar
+    open dynamic var willDismissBlock: TTGDismissBlock? = nil
+
     /// Dismiss callback.
     open dynamic var dismissBlock: TTGDismissBlock? = nil
 
@@ -664,6 +667,7 @@ public extension TTGSnackbar {
 
         setNeedsLayout()
         
+        willDismissBlock?(self)
         UIView.animate(withDuration: animationDuration, delay: 0,
                        usingSpringWithDamping: animationSpringWithDamping,
                        initialSpringVelocity: animationInitialSpringVelocity, options: .curveEaseIn,

--- a/TTGSnackbar/TTGSnackbar.swift
+++ b/TTGSnackbar/TTGSnackbar.swift
@@ -467,8 +467,19 @@ public extension TTGSnackbar {
         
         addConstraints([contentViewTopConstraint!, contentViewBottomConstraint!, contentViewLeftConstraint!, contentViewRightConstraint!])
 
+        // We always want to present in the main window of the app, but we can't
+        // use UIApplication.shared.keyWindow because it's different when using
+        // a whisper library that modifies the status bar.
+        var windowToUse: UIWindow?
+        for window in UIApplication.shared.windows {
+            if window.windowLevel == UIWindowLevelNormal {
+                windowToUse = window
+                break
+            }
+        }
+
         // Get super view to show
-        if let superView = containerView ?? UIApplication.shared.keyWindow {
+        if let superView = containerView ?? windowToUse {
             superView.addSubview(self)
             
             // Left margin constraint


### PR DESCRIPTION
@AndrewGable, please review

### Description

This update makes two changes:

- We always display from window level, `UIWindowLevelNormal`. This is important because the whisper library actually presents a 3rd window that only exists in the upper portion of the app. And while the whisper was visible, the `keyWindow` of the app was that upper window and not the window that houses the actual SlidingController and all of our view controllers. 

![image](https://cloud.githubusercontent.com/assets/12702568/25730302/f31621c4-30e7-11e7-84ac-1a7c6248a402.png)

- We now fire an event before starting the dismiss animation. This allows our SmartScan button to animate at the same time and rest its position

<img width=250 src=http://g.recordit.co/wZZFi9bzdT.gif>

### Tests

Tests will be run from the related Mobile PR 