### PR TITLE
Fix nil superview crash

### DIFF
--- a/TTGSnackbar/TTGSnackbar.swift
+++ b/TTGSnackbar/TTGSnackbar.swift
@@ -688,7 +688,8 @@ public extension TTGSnackbar {
      */
     fileprivate func dismissAnimated(_ animated: Bool) {
         // If the dismiss timer is nil, snackbar is dismissing or not ready to dismiss.
-        if dismissTimer == nil {
+        // If superview is nil it means the snakbar no longer needs to be dismissed
+        guard dismissTimer != nil, superview != nil else {
             return
         }
         


### PR DESCRIPTION
@migfabio please take a look

This should fix https://github.com/Expensify/Expensify/issues/118818.

Was unable to replicate the crash itself, but guarding against the superview being nil should protect against this crash.
As such there are no tests.